### PR TITLE
Add check for setting new_polarity to ch_polarity

### DIFF
--- a/code/src/pwm.cpp
+++ b/code/src/pwm.cpp
@@ -154,9 +154,9 @@ namespace R2D2::pwm_lib {
         }
     }
     
-    void pwm_c::set_polarity(polarity new_polartiy) {
+    void pwm_c::set_polarity(polarity new_polarity) {
 	if (new_polarity != ch_polarity){
-            ch_polarity = new_polartiy;
+            ch_polarity = new_polarity;
             if (ch_polarity == polarity::NEGATIVE){
                 PWM->PWM_CH_NUM[ch_nr].PWM_CMR |= PWM_CMR_CPOL;
             } else {

--- a/code/src/pwm.cpp
+++ b/code/src/pwm.cpp
@@ -155,14 +155,16 @@ namespace R2D2::pwm_lib {
     }
     
     void pwm_c::set_polarity(polarity new_polarity) {
-	if (new_polarity != ch_polarity){
-            ch_polarity = new_polarity;
-            if (ch_polarity == polarity::NEGATIVE){
-                PWM->PWM_CH_NUM[ch_nr].PWM_CMR |= PWM_CMR_CPOL;
-            } else {
-                PWM->PWM_CH_NUM[ch_nr].PWM_CMR &= ~PWM_CMR_CPOL;
-            }
-	}
+        if (new_polarity == ch_polarity) {
+            return;
+        }
+
+        ch_polarity = new_polarity;
+        if (ch_polarity == polarity::NEGATIVE) {
+            PWM->PWM_CH_NUM[ch_nr].PWM_CMR |= PWM_CMR_CPOL;
+        } else {
+            PWM->PWM_CH_NUM[ch_nr].PWM_CMR &= ~PWM_CMR_CPOL;
+        }
     }
 }
     

--- a/code/src/pwm.cpp
+++ b/code/src/pwm.cpp
@@ -155,12 +155,14 @@ namespace R2D2::pwm_lib {
     }
     
     void pwm_c::set_polarity(polarity new_polartiy) {
-        ch_polarity = new_polartiy;
-        if (ch_polarity == polarity::NEGATIVE){
-            PWM->PWM_CH_NUM[ch_nr].PWM_CMR |= PWM_CMR_CPOL;
-        } else {
-            PWM->PWM_CH_NUM[ch_nr].PWM_CMR &= ~PWM_CMR_CPOL;
-        }
+	if (new_polarity != ch_polarity){
+            ch_polarity = new_polartiy;
+            if (ch_polarity == polarity::NEGATIVE){
+                PWM->PWM_CH_NUM[ch_nr].PWM_CMR |= PWM_CMR_CPOL;
+            } else {
+                PWM->PWM_CH_NUM[ch_nr].PWM_CMR &= ~PWM_CMR_CPOL;
+            }
+	}
     }
 }
     


### PR DESCRIPTION
Add a check that prevents changing the polarity when the current polarity is the new polarity. This will prevent unwanted behavior.